### PR TITLE
Make only intended charts draggable

### DIFF
--- a/draggable-points.js
+++ b/draggable-points.js
@@ -32,8 +32,15 @@
             dragX,
             dragY,
             dragPlotX,
-            dragPlotY;
-
+            dragPlotY,
+			draggable = chart.options.chart.draggable;
+        
+        // set chart.draggable = true to enable dragging
+        if (!draggable) {
+            return false;
+        }
+        
+        // this seems to cause reduced padding on other charts
         chart.redraw(); // kill animation (why was this again?)
 
         addEvent(container, 'mousedown', function (e) {
@@ -134,7 +141,11 @@
         baseDrawTracker = colProto.drawTracker;
 
     colProto.drawTracker = function () {
-        var series = this;
+        var series = this,
+			userOptions = series.userOptions;
+		if (!userOptions.draggableY && !userOptions.draggableX) {
+			return false; // don't change non-draggable charts
+		}
         baseDrawTracker.apply(series);
         each(series.points, function (point) {
             point.graphic.attr(point.shapeArgs.height < 3 ? {

--- a/draggable-points.js
+++ b/draggable-points.js
@@ -33,7 +33,7 @@
             dragY,
             dragPlotX,
             dragPlotY,
-			draggable = chart.options.chart.draggable;
+            draggable = chart.options.chart.draggable;
         
         // set chart.draggable = true to enable dragging
         if (!draggable) {
@@ -142,11 +142,11 @@
 
     colProto.drawTracker = function () {
         var series = this,
-			userOptions = series.userOptions;
-		if (!userOptions.draggableY && !userOptions.draggableX) {
-			return false; // don't change non-draggable charts
-		}
-        baseDrawTracker.apply(series);
+            userOptions = series.userOptions;
+	baseDrawTracker.apply(series);
+	if (!userOptions.draggableY && !userOptions.draggableX) {
+		return false; // don't change non-draggable charts
+	}
         each(series.points, function (point) {
             point.graphic.attr(point.shapeArgs.height < 3 ? {
                 'stroke': 'black',


### PR DESCRIPTION
On a page with other charts, this plugin seemed to reduce the chart padding with the `chart.redraw()` line, and made columns have a dotted border if the values were near 0 (which should happen on draggable charts).  I think if you want to have a draggable chart, you shouldn't have to have these events and styles affect other charts.

![badpadding](https://f.cloud.github.com/assets/1410985/1935380/f3dcb4f0-7ef8-11e3-9636-c2b9193b3cad.png)
Above is some non-draggable charts with `chart.redraw()` triggered.

![betterpadding](https://f.cloud.github.com/assets/1410985/1935386/02c5c5ba-7ef9-11e3-8bdf-d5473c95c042.png)
And without `chart.redraw()` in the draggable-points plugin.  Note the dotted columns in the column chart are still there without the `drawTracker` fix.